### PR TITLE
fix: Add entrypoint script to fix Docker permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-# Use an official Node.js runtime as a parent image
 FROM node:18-slim
 
-# Set the working directory in the container
-WORKDIR /usr/src/app
+WORKDIR /home/node/app
 
-# Copy package.json and package-lock.json to the working directory
+# Copy package files and install dependencies
+# This is done as root, which is fine.
 COPY package*.json ./
-
-# Install any needed packages
 RUN npm install
 
-# Bundle app source
+# Copy app source
 COPY . .
 
-# Make port 8080 available to the world outside this container
+# Copy entrypoint and make it executable
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
 EXPOSE 8282
 
-# Define the command to run the app
+ENTRYPOINT ["/home/node/app/entrypoint.sh"]
+# The CMD will be passed to the entrypoint, which will then execute it as the 'node' user.
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -31,22 +31,14 @@ A simple web application to display a calendar and populate it with events from 
 
 ### Running with Docker Compose
 
-**1. Important First Step!**
+1.  **Build and Run**
 
-Before running `docker-compose` for the first time, you **must** create an empty `events.json` file in the root of the project. This is required to ensure Docker correctly mounts a file, not a directory.
-
-```bash
-touch events.json
-```
-
-**2. Build and Run**
-
-Now, you can build and run the application:
+    Simply build and run the application using Docker Compose. The server will automatically create the necessary data file inside a Docker-managed volume.
 ```bash
 docker-compose up --build
 ```
 
-**3. View the Application**
+**2. View the Application**
 
 Open your browser and navigate to `http://localhost:8282`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8282:8282"
     volumes:
-      - ./events.json:/usr/src/app/events.json
-    # It's good practice to create the events.json file on the host
-    # if it doesn't exist, to avoid Docker creating it as a directory.
-    # You can do this by running `touch events.json` before `docker-compose up`.
+      - event-data:/home/node/app/data
+
+volumes:
+  event-data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# This script is run as the root user when the container starts.
+
+# Take ownership of the app data directory.
+# This is necessary because Docker mounts the named volume as root, but the
+# application runs as the non-root 'node' user.
+chown -R node:node /home/node/app/data
+
+# Drop privileges and execute the main command (e.g., "npm start") as the 'node' user.
+exec su-exec node "$@"

--- a/server.js
+++ b/server.js
@@ -4,9 +4,13 @@ const path = require('path');
 
 const app = express();
 const port = process.env.PORT || 8282;
-const eventsFilePath = path.join(__dirname, 'events.json');
+const dataDir = path.join(__dirname, 'data');
+const eventsFilePath = path.join(dataDir, 'events.json');
 
 async function initialize() {
+    // Ensure the data directory exists
+    await fs.mkdir(dataDir, { recursive: true });
+
     try {
         const stats = await fs.stat(eventsFilePath);
         if (stats.isDirectory()) {


### PR DESCRIPTION
This commit fixes a critical file permission issue when using a named volume in Docker. The container's `node` user did not have permission to write to the root-owned volume mount point.

Key Changes:
- An `entrypoint.sh` script has been added to `chown` the data directory to the `node` user before the application starts.
- The entrypoint then uses `su-exec` to run the main application as the non-root `node` user, following security best practices.
- The `Dockerfile` has been updated to copy and use this entrypoint script.

This commit should finally resolve all stability and deployment issues. It also includes all previously developed features.